### PR TITLE
Add Parent pom for ease of use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.microsoft.gbb</groupId>
+    <artifactId>reddog-quarkus</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>reddog-quarkus</name>
+    <packaging>pom</packaging>
+    <description>RedDog Quarkus</description>
+    
+    <modules>
+        <module>order-service</module>
+    </modules>
+</project>


### PR DESCRIPTION
I've created a parent pom just to ease opening the project on an IDE and also compiling and testing the entire app. Child poms do not inherit from this pom, it just aggregates .

I did like https://github.com/appdevgbb/reddog-code-spring/pull/52